### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install appscript
 python3 apple-calendar.py
 ```
 
-Note: Make sure to have the Calendar app open while running the script for the events to be added to the calendar. The first time you run the script you will **be** prompted to allow access to the Calendar app. You will need to allow access for the script to work.
+Note: Make sure to have the Calendar app open while running the script for the events to be added to the calendar. The first time you run the script you will be prompted to allow access to the Calendar app. You will need to allow access for the script to work.
 
 ## ToDo
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install appscript
 python3 apple-calendar.py
 ```
 
-Note: Make sure to have the Calendar app open while running the script for the events to be added to the calendar. The first time you run the script you will prompted to allow access to the Calendar app. You will need to allow access for the script to work.
+Note: Make sure to have the Calendar app open while running the script for the events to be added to the calendar. The first time you run the script you will **be** prompted to allow access to the Calendar app. You will need to allow access for the script to work.
 
 ## ToDo
 


### PR DESCRIPTION
## Summary
- fix a missing word in instructions about accessing the Calendar app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505ec769a48320832ba514df853c80